### PR TITLE
Testar a ideia do spec.files

### DIFF
--- a/anvil.gemspec
+++ b/anvil.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.description           = 'Ruby wrapper for the REST API for Conviso Armature'
   s.authors               = ['Anezio Campos']
   s.email                 = 'newdevas@gmail.com'
-  s.files                 = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  s.files                 = Dir["lib/**/*.rb", "ext/**/*.{c,h,rb}", "*.md", "BSDL", "LICENSE.txt"]
   s.homepage              = 'http://app.conviso.com.br'
   s.license               = 'MIT'
   s.required_ruby_version = '>= 2.4.2'


### PR DESCRIPTION
`git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
Deixando isso aqui pra caso tenhamos que voltar atrás